### PR TITLE
Updated select statement to use a more friendly PS3 variable

### DIFF
--- a/desktop
+++ b/desktop
@@ -493,7 +493,7 @@ function main {
         esac
     
     else
-        PS3="Please select one of the preceeding options: "
+        PS3="Please select one of the preceding options: "
         select operation in "$echo_install" "$echo_stop" "$echo_start" "$echo_restart" "$echo_reinstall" "$echo_info" "$echo_checkUpdate" "$echo_update" "$echo_uninstall" "$echo_ssh" "$echo_help" "quit"; do
         case $operation in
             "$echo_install") operation="install"; checkPreReqs;  installPanamax; break;;


### PR DESCRIPTION
It would be helpful to have the PS3 variable changed rather than using the default prompt of #?.
