### PR TITLE
Wrong URI format COREOS_ENDPOINT

### DIFF
--- a/coreos
+++ b/coreos
@@ -146,7 +146,7 @@ function getRunCmdAPI {
 
     docker_ip="`ifconfig docker0 2>/dev/null | grep 'inet '| awk '{print $2}'`"
     if [[ "$docker_ip" != "" ]]; then
-        COREOS_ENDPOINT=$docker_ip
+        COREOS_ENDPOINT="http://$docker_ip"
     fi
     echo "/usr/bin/docker run --name $CONTAINER_NAME_API $dbMount -m=1g -c=10 -v /var/run/docker.sock:/run/docker.sock:rw -e PANAMAX_ID="$PANAMAX_ID" -e JOURNAL_ENDPOINT=$COREOS_ENDPOINT:19531 -e FLEETCTL_ENDPOINT=$COREOS_ENDPOINT:4001 -t  -p 3001:3000 " $REPO_URL_NAMESPACE/$IMAGE_API:$IMAGE_TAG
 }


### PR DESCRIPTION
COREOS_ENDPOINT is must be a URI format.　Can not start the Panamax Template and docker image in a coreos host, and can not get the containers output log.
