### PR TITLE
Added test to ensure the machine has virtualization options before pr…

### DIFF
--- a/ubuntu.sh
+++ b/ubuntu.sh
@@ -1,5 +1,15 @@
 #!/bin/sh
 
+# Test if the system has virtualization
+if [[ "$(egrep -c svm\|vmx /proc/cpuinfo)" -gt "0" ]]
+	then
+		echo "Virtualization detected. Proceeding"
+	else 
+		echo "No Virtualization options detected!"
+		echo "Panamax requires virtualization options to function. Please attempt on a machine with VT-x or AMD-V available."
+		exit 1
+fi 
+
 installer='panamax-latest.tar.gz'
 destination=~/.panamax
 curl -O "http://download.panamax.io/installer/$installer"


### PR DESCRIPTION
…oceeding with the download.

Otherwise a machine which has Vagrant and Virtualbox installed (even though Virtualbox won't work) but has no virtualization options will go through the whole install before Virtualbox will finally refuse to start the VM without the Virt flags/options exposed.

Tested on Xubuntu 14.04, but the commands/expectations involved would be present on any ubuntu version 12+ which is what the install script is for.
